### PR TITLE
Fixing gem incompatibility

### DIFF
--- a/lib/cap-aws-ec2.rb
+++ b/lib/cap-aws-ec2.rb
@@ -39,7 +39,7 @@ class CapAwsEc2
               Aws.config = { access_key_id: @key,
                              secret_access_key: @secret,
                              region: @region }
-              Aws::EC2.new
+              Aws::EC2::Client.new
              end
   end
 


### PR DESCRIPTION
the Aws gem has changed, no longer called using Aws::EC2.new but Aws::EC2::Client.new
